### PR TITLE
make sure prototype of Dial() implementation is same as in declaration

### DIFF
--- a/openmcu-ru/conference.cxx
+++ b/openmcu-ru/conference.cxx
@@ -1501,7 +1501,7 @@ void ConferenceMember::Dial()
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void ConferenceMember::Dial(BOOL _autoDial)
+void ConferenceMember::Dial(int _autoDial)
 {
   if(IsSystem())
     return;


### PR DESCRIPTION
This is needed to compile with newer versions of H323Plus and is cleaner code anyway.
